### PR TITLE
making check method protected

### DIFF
--- a/src/main/java/com/idealista/fpe/FormatPreservingEncryption.java
+++ b/src/main/java/com/idealista/fpe/FormatPreservingEncryption.java
@@ -37,7 +37,7 @@ public class FormatPreservingEncryption {
         return selectedDomain.transform(numeralPlainText);
     }
 
-    private void check(String text, byte[] tweak) {
+    protected void check(String text, byte[] tweak) {
         if (text == null || tweak == null)
             throw  new IllegalArgumentException(NULL_INPUT.toString());
 


### PR DESCRIPTION
Making check method protected. This is for
https://github.com/idealista/format-preserving-encryption-java/issues/15
### Description of the Change

This PR is based on the issue- https://github.com/idealista/format-preserving-encryption-java/issues/15
The aim is to make the check method extendible.


### Benefits

We will be able to add custom checks including based on regular expressions by just instantiating a derived class and overriding the check method in a custom builder similar to FormatPreservingEncryptionBuilder.

### Possible Drawbacks

As of now must write a custom builder similar to FormatPreservingEncryptionBuilder

### Applicable Issues

https://github.com/idealista/format-preserving-encryption-java/issues/15
